### PR TITLE
fix conda env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+datasets/
+
+__pycache__/
+*.py[cod]
+
+build/
+dist/
+*.egg-info/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "justMyCode": false
+        },
+        {
+            "name": "train playground",
+            "type": "python",
+            "request": "launch",
+            "program": "main.py",
+            "console": "integratedTerminal",
+            "justMyCode": false,
+            "args": [
+                "--dataset",
+                "playroom",
+                "--batch_size",
+                "8",
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ We have tested our code using Pytorch 1.11 and CUDA 11.3. We recommend installat
 ```
 conda env create -f environment.yml
 conda activate eisen
+# install external pip dependencies
+pip install -r requirements.txt
 ```
 
 ## Dataset

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: eisen
+name: eisen2
 channels:
   - pytorch
   - defaults
@@ -73,14 +73,11 @@ dependencies:
   - pip:
     - absl-py==1.1.0
     - antlr4-python3-runtime==4.9.3
-    - black==22.3.0
     - blessings==1.7
     - cachetools==5.2.0
-    - cc-torch==0.1
     - click==8.1.3
     - cloudpickle==2.1.0
     - cycler==0.11.0
-    - detectron2==0.6
     - docker-pycreds==0.4.0
     - fairscale==0.4.6
     - fonttools==4.34.4
@@ -153,4 +150,3 @@ dependencies:
     - werkzeug==2.1.2
     - yacs==0.1.8
     - zipp==3.8.1
-

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: eisen2
+name: eisen
 channels:
   - pytorch
   - defaults

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/facebookresearch/Detectron2.git@v0.6
+git+https://github.com/zsef123/Connected_components_PyTorch


### PR DESCRIPTION
Addresses https://github.com/neuroailab/EISEN/issues/1

Chose to have detectron and cc_torch in a separate file as they can take time to install. We can move it to pip section in conda ofc, but I think they take time to compile and user doesn't get any info while they're compiling, which makes it seems things are stuck.

conda's verbose option doesn't show pip install logs: https://github.com/conda/conda/issues/10556


Also, as I mentioned in the issue, it is not clear if raft and cc_torch could just be external dependencies or any changes have been made to them?
